### PR TITLE
Add `encoding-type` parameter. Requests Amazon S3 to encode the objec…

### DIFF
--- a/src/org/jets3t/service/impl/rest/httpclient/RestS3Service.java
+++ b/src/org/jets3t/service/impl/rest/httpclient/RestS3Service.java
@@ -502,6 +502,7 @@ public class RestS3Service extends S3Service {
         throws S3ServiceException
     {
         Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("encoding-type", "url");
         parameters.put("versions", null);
         if (prefix != null) {
             parameters.put("prefix", prefix);

--- a/src/org/jets3t/service/impl/rest/httpclient/RestStorageService.java
+++ b/src/org/jets3t/service/impl/rest/httpclient/RestStorageService.java
@@ -1523,6 +1523,7 @@ public abstract class RestStorageService extends StorageService implements JetS3
             boolean automaticallyMergeChunks, String priorLastKey)
             throws ServiceException {
         Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("encoding-type", "url");
         if(prefix != null) {
             parameters.put("prefix", prefix);
         }


### PR DESCRIPTION
…t keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response.